### PR TITLE
Introduce inheritance for common mercury plugin resources

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -36,7 +36,7 @@ find_package(Log4CXX 0.10.0 REQUIRED)
 find_package(ZeroMQ 3.2.4 REQUIRED)
 find_package(OdinData REQUIRED)
 
-message("Determining hexitec-detector version")
+message("Determining mercury-detector version")
 include(GetGitRevisionDescription)
 git_describe(GIT_DESC_STR)
 

--- a/data/frameProcessor/include/MercuryProcessorPlugin.h
+++ b/data/frameProcessor/include/MercuryProcessorPlugin.h
@@ -1,0 +1,76 @@
+/*
+ * MercuryProcessorPlugin.h
+ *
+ *  Created on: 23 Sep 2020
+ *      Author: ckd27546
+ */
+
+#ifndef TOOLS_FILEWRITER_MercuryProcessorPlugin_H_
+#define TOOLS_FILEWRITER_MercuryProcessorPlugin_H_
+
+#include <log4cxx/logger.h>
+#include <log4cxx/basicconfigurator.h>
+#include <log4cxx/propertyconfigurator.h>
+#include <log4cxx/helpers/exception.h>
+using namespace log4cxx;
+using namespace log4cxx::helpers;
+
+
+#include "FrameProcessorPlugin.h"
+#include "MercuryDefinitions.h"
+#include "ClassLoader.h"
+#include <boost/algorithm/string.hpp>
+#include <map>
+
+namespace FrameProcessor
+{
+  typedef std::map<int, Mercury::MercurySensorLayoutMapEntry> MercurySensorLayoutMap;
+
+  /** Abstract plugin class, providing common components to all Mercury plugins.
+   *
+   * All OdinData Mercury plugins must subclass this class. It provides the
+   * FrameProcessorPlugin interface to all Mercury plugins. It also provides 
+   * methods for configuring plugins and for retrieving status from plugins.
+   */
+  class MercuryProcessorPlugin: public FrameProcessorPlugin
+  {
+    public:
+      MercuryProcessorPlugin();
+      virtual ~MercuryProcessorPlugin();
+
+      int get_version_major();
+      int get_version_minor();
+      int get_version_patch();
+      std::string get_version_short();
+      std::string get_version_long();
+
+      virtual void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
+      virtual void requestConfiguration(OdinData::IpcMessage& reply);
+      virtual void status(OdinData::IpcMessage& status);
+      virtual bool reset_statistics();
+
+    private:
+      /** Configuration constant for Hardware sensors **/
+      static const std::string CONFIG_SENSORS_LAYOUT;
+
+      std::size_t parse_sensors_layout_map(const std::string sensors_layout_str);
+      std::string sensors_layout_str_;
+      MercurySensorLayoutMap sensors_layout_;
+
+      virtual void process_frame(boost::shared_ptr<Frame> frame); // Should be without '= 0' attached?
+
+      // virtual void process_frame(boost::shared_ptr<Frame> frame) = 0;
+
+      /** Pointer to logger **/
+      LoggerPtr logger_;
+      /** Image width **/
+      int image_width_;
+      /** Image height **/
+      int image_height_;
+      /** Image pixel count **/
+      int image_pixels_;
+  };
+
+} /* namespace FrameProcessor */
+
+#endif /* TOOLS_FILEWRITER_MercuryProcessorPlugin_H_ */

--- a/data/frameProcessor/include/MercuryTemplatePlugin.h
+++ b/data/frameProcessor/include/MercuryTemplatePlugin.h
@@ -28,7 +28,7 @@ namespace FrameProcessor
 
   /** Template for future Mercury Frame objects.
    *
-   * This template may be the basis for any future hexitec plug-in(s).
+   * This template may be the basis for any future Mercury plug-in(s).
    */
   class MercuryTemplatePlugin : public FrameProcessorPlugin
   {

--- a/data/frameProcessor/include/MercuryTemplatePlugin.h
+++ b/data/frameProcessor/include/MercuryTemplatePlugin.h
@@ -8,19 +8,7 @@
 #ifndef INCLUDE_MERCURYTEMPLATEPLUGIN_H_
 #define INCLUDE_MERCURYTEMPLATEPLUGIN_H_
 
-#include <log4cxx/logger.h>
-#include <log4cxx/basicconfigurator.h>
-#include <log4cxx/propertyconfigurator.h>
-#include <log4cxx/helpers/exception.h>
-using namespace log4cxx;
-using namespace log4cxx::helpers;
-
-
-#include "FrameProcessorPlugin.h"
-#include "MercuryDefinitions.h"
-#include "ClassLoader.h"
-#include <boost/algorithm/string.hpp>
-#include <map>
+#include "MercuryProcessorPlugin.h"
 
 namespace FrameProcessor
 {
@@ -30,17 +18,11 @@ namespace FrameProcessor
    *
    * This template may be the basis for any future Mercury plugin(s).
    */
-  class MercuryTemplatePlugin : public FrameProcessorPlugin
+  class MercuryTemplatePlugin : public MercuryProcessorPlugin
   {
     public:
       MercuryTemplatePlugin();
       virtual ~MercuryTemplatePlugin();
-
-      int get_version_major();
-      int get_version_minor();
-      int get_version_patch();
-      std::string get_version_short();
-      std::string get_version_long();
 
       void configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply);
       void requestConfiguration(OdinData::IpcMessage& reply);

--- a/data/frameProcessor/src/CMakeLists.txt
+++ b/data/frameProcessor/src/CMakeLists.txt
@@ -7,5 +7,7 @@ include_directories(${FRAMEPROCESSOR_DIR}/include ${ODINDATA_INCLUDE_DIRS}
 
 # Add library for mercury plugin
 add_library(MercuryTemplatePlugin SHARED MercuryTemplatePlugin.cpp)
+add_library(MercuryProcessorPlugin SHARED MercuryProcessorPlugin.cpp)
 
 install(TARGETS MercuryTemplatePlugin LIBRARY DESTINATION lib)
+install(TARGETS MercuryProcessorPlugin LIBRARY DESTINATION lib)

--- a/data/frameProcessor/src/MercuryProcessorPlugin.cpp
+++ b/data/frameProcessor/src/MercuryProcessorPlugin.cpp
@@ -1,0 +1,109 @@
+/*
+ * MercuryProcessorPlugin.cpp
+ * 
+ *  Created on: 23 Sep 2020
+ *      Author: Christian Angelsen
+ */
+
+#include <MercuryProcessorPlugin.h>
+#include "version.h"
+
+namespace FrameProcessor
+{
+  const std::string MercuryProcessorPlugin::CONFIG_SENSORS_LAYOUT  = "sensors_layout";
+
+  /**
+   * The constructor sets up logging used within the class.
+   */
+
+  MercuryProcessorPlugin::MercuryProcessorPlugin() :
+      image_width_(Mercury::pixel_columns_per_sensor),
+      image_height_(Mercury::pixel_rows_per_sensor),
+      image_pixels_(image_width_ * image_height_)
+  {
+    sensors_layout_str_ = Mercury::default_sensors_layout_map;
+    parse_sensors_layout_map(sensors_layout_str_);
+  }
+
+  /**
+   * Destructor.
+   */
+  MercuryProcessorPlugin::~MercuryProcessorPlugin()
+  {
+    // Destructor needing to do anything?
+    // LOG4CXX_TRACE(logger_, "MercuryProcessorPlugin destructor.");
+  }
+
+  int MercuryProcessorPlugin::get_version_major()
+  {
+    return ODIN_DATA_VERSION_MAJOR;
+  }
+
+  int MercuryProcessorPlugin::get_version_minor()
+  {
+    return ODIN_DATA_VERSION_MINOR;
+  }
+
+  int MercuryProcessorPlugin::get_version_patch()
+  {
+    return ODIN_DATA_VERSION_PATCH;
+  }
+
+  std::string MercuryProcessorPlugin::get_version_short()
+  {
+    return ODIN_DATA_VERSION_STR_SHORT;
+  }
+
+  std::string MercuryProcessorPlugin::get_version_long()
+  {
+    return ODIN_DATA_VERSION_STR;
+  }
+
+  /**
+   * Reset process plugin statistics
+   */
+  bool MercuryProcessorPlugin::reset_statistics(void)
+  {
+    return true;
+  }
+
+  /**
+   * Parse the number of sensors map configuration string.
+   * 
+   * This method parses a configuration string containing number of sensors mapping information,
+   * which is expected to be of the format "NxN" e.g, 2x2. The map's saved in a member variable.
+   * 
+   * \param[in] sensors_layout_str - string of number of sensors configured
+   * \return number of valid map entries parsed from string
+   */
+  std::size_t MercuryProcessorPlugin::parse_sensors_layout_map(const std::string sensors_layout_str)
+  {
+    // Clear the current map
+    sensors_layout_.clear();
+
+    // Define entry and port:idx delimiters
+    const std::string entry_delimiter("x");
+
+    // Vector to hold entries split from map
+    std::vector<std::string> map_entries;
+
+    // Split into entries
+    boost::split(map_entries, sensors_layout_str, boost::is_any_of(entry_delimiter));
+
+    // If a valid entry is found, save into the map
+    if (map_entries.size() == 2) {
+      int sensor_rows = static_cast<int>(strtol(map_entries[0].c_str(), NULL, 10));
+      int sensor_columns = static_cast<int>(strtol(map_entries[1].c_str(), NULL, 10));
+      sensors_layout_[0] = Mercury::MercurySensorLayoutMapEntry(sensor_rows, sensor_columns);
+    }
+
+    image_width_ = sensors_layout_[0].sensor_columns_ * Mercury::pixel_columns_per_sensor;
+    image_height_ = sensors_layout_[0].sensor_rows_ * Mercury::pixel_rows_per_sensor;
+    image_pixels_ = image_width_ * image_height_;
+
+    // Return the number of valid entries parsed
+    return sensors_layout_.size();
+  }
+
+
+}

--- a/data/frameProcessor/src/MercuryTemplatePlugin.cpp
+++ b/data/frameProcessor/src/MercuryTemplatePlugin.cpp
@@ -15,19 +15,13 @@ namespace FrameProcessor
   /**
    * The constructor sets up logging used within the class.
    */
-  MercuryTemplatePlugin::MercuryTemplatePlugin() :
-      image_width_(Mercury::pixel_columns_per_sensor),
-      image_height_(Mercury::pixel_rows_per_sensor),
-      image_pixels_(image_width_ * image_height_)
+  MercuryTemplatePlugin::MercuryTemplatePlugin()
   {
     // Setup logging for the class
     logger_ = Logger::getLogger("FP.MercuryTemplatePlugin");
     logger_->setLevel(Level::getAll());
     LOG4CXX_TRACE(logger_, "MercuryTemplatePlugin version " <<
                   this->get_version_long() << " loaded.");
-
-    sensors_layout_str_ = Mercury::default_sensors_layout_map;
-    parse_sensors_layout_map(sensors_layout_str_);
   }
 
   /**
@@ -36,31 +30,6 @@ namespace FrameProcessor
   MercuryTemplatePlugin::~MercuryTemplatePlugin()
   {
     LOG4CXX_TRACE(logger_, "MercuryTemplatePlugin destructor.");
-  }
-
-  int MercuryTemplatePlugin::get_version_major()
-  {
-    return ODIN_DATA_VERSION_MAJOR;
-  }
-
-  int MercuryTemplatePlugin::get_version_minor()
-  {
-    return ODIN_DATA_VERSION_MINOR;
-  }
-
-  int MercuryTemplatePlugin::get_version_patch()
-  {
-    return ODIN_DATA_VERSION_PATCH;
-  }
-
-  std::string MercuryTemplatePlugin::get_version_short()
-  {
-    return ODIN_DATA_VERSION_STR_SHORT;
-  }
-
-  std::string MercuryTemplatePlugin::get_version_long()
-  {
-    return ODIN_DATA_VERSION_STR;
   }
 
   /**
@@ -99,16 +68,6 @@ namespace FrameProcessor
     // Record the plugin's status items
     LOG4CXX_DEBUG(logger_, "Status requested for MercuryTemplatePlugin");
     status.set_param(get_name() + "/sensors_layout", sensors_layout_str_);
-  }
-
-  /**
-   * Reset process plugin statistics
-   */
-  bool MercuryTemplatePlugin::reset_statistics(void)
-  {
-    // Nowt to reset..?
-
-    return true;
   }
 
   /**
@@ -152,51 +111,13 @@ namespace FrameProcessor
       }
       catch (const std::exception& e)
       {
-        LOG4CXX_ERROR(logger_, "MercuryTemplatePluginfailed: " << e.what());
+        LOG4CXX_ERROR(logger_, "MercuryTemplatePlugin failed: " << e.what());
       }
     }
     else
     {
       LOG4CXX_ERROR(logger_, "Unknown dataset encountered: " << dataset);
     }
-  }
-
-  /**
-   * Parse the number of sensors map configuration string.
-   * 
-   * This method parses a configuration string containing number of sensors mapping information,
-   * which is expected to be of the format "NxN" e.g, 2x2. The map's saved in a member variable.
-   * 
-   * \param[in] sensors_layout_str - string of number of sensors configured
-   * \return number of valid map entries parsed from string
-   */
-  std::size_t MercuryTemplatePlugin::parse_sensors_layout_map(const std::string sensors_layout_str)
-  {
-    // Clear the current map
-    sensors_layout_.clear();
-
-    // Define entry and port:idx delimiters
-    const std::string entry_delimiter("x");
-
-    // Vector to hold entries split from map
-    std::vector<std::string> map_entries;
-
-    // Split into entries
-    boost::split(map_entries, sensors_layout_str, boost::is_any_of(entry_delimiter));
-
-    // If a valid entry is found, save into the map
-    if (map_entries.size() == 2) {
-      int sensor_rows = static_cast<int>(strtol(map_entries[0].c_str(), NULL, 10));
-      int sensor_columns = static_cast<int>(strtol(map_entries[1].c_str(), NULL, 10));
-      sensors_layout_[0] = Mercury::MercurySensorLayoutMapEntry(sensor_rows, sensor_columns);
-    }
-
-    image_width_ = sensors_layout_[0].sensor_columns_ * Mercury::pixel_columns_per_sensor;
-    image_height_ = sensors_layout_[0].sensor_rows_ * Mercury::pixel_rows_per_sensor;
-    image_pixels_ = image_width_ * image_height_;
-
-    // Return the number of valid entries parsed
-    return sensors_layout_.size();
   }
 
 } /* namespace FrameProcessor */

--- a/data/frameReceiver/src/CMakeLists.txt
+++ b/data/frameReceiver/src/CMakeLists.txt
@@ -5,4 +5,4 @@ ADD_DEFINITIONS(-DBUILD_DIR="${CMAKE_BINARY_DIR}")
 include_directories(${FRAMERECEIVER_DIR}/include ${ODINDATA_INCLUDE_DIRS} 
 	${Boost_INCLUDE_DIRS} ${LOG4CXX_INCLUDE_DIRS}/.. ${ZEROMQ_INCLUDE_DIRS})
 
-# Add library for Hexitec frame decoder
+# Add library for Mercury frame decoder


### PR DESCRIPTION
This PR will take functions and variables that are common across Mercury plugins and move them into the parent class MercuryProcessorPlugin. This class sits between Odin Data's FrameProcessorPlugin and each Mercury plugin(s), to be written.