### PR TITLE
Improve Integration Test

### DIFF
--- a/data/test/integrationTest/config/mercury-average.json
+++ b/data/test/integrationTest/config/mercury-average.json
@@ -2,25 +2,25 @@
     "Main": {
         "receiver": {
             "process": true,
-            "command": "${ODIN_PREFIX}\/bin\/frameReceiver",
+            "command": "${INSTALL_PREFIX}\/bin\/frameReceiver",
             "pos-args": "",
-            "sleep": 10
+            "sleep": 2
         },
         "processor": {
             "process": true,
-            "command": "${ODIN_PREFIX}\/bin\/frameProcessor",
+            "command": "${INSTALL_PREFIX}\/bin\/frameProcessor",
             "pos-args": "",
-            "sleep": 10
+            "sleep": 2
         },
         "simulator": {
             "process": false,
-            "command": "${ODIN_PREFIX}\/bin\/frameSimulator",
+            "command": "${INSTALL_PREFIX}\/bin\/frameSimulator",
             "pos-args": "Mercury",
             "sleep": 1
         },
         "test": {
             "process": false,
-            "command": "${ODIN_PREFIX}\/bin\/frameTests",
+            "command": "${INSTALL_PREFIX}\/bin\/frameTests --log_level=all -- ",
             "pos-args": "",
             "sleep": 1
         }
@@ -45,7 +45,6 @@
     },
     "test":
     {
-        "json": "${INSTALL_PREFIX}\/test_config\/test-average.json",
-        "log_level": "ALL"
+        "json": "${INSTALL_PREFIX}\/test_config\/test-average.json"
     }
 }

--- a/data/test/integrationTest/config/mercury-fp-average.json
+++ b/data/test/integrationTest/config/mercury-fp-average.json
@@ -11,7 +11,7 @@
             "load": {
                 "index":"hdf",
                 "name":"FileWriterPlugin",
-                "library":"${ODIN_PREFIX}/lib/libHdf5Plugin.so"
+                "library":"${INSTALL_PREFIX}/lib/libHdf5Plugin.so"
             }
         }
     },
@@ -149,9 +149,6 @@
                     "chunks": [1, 800],
                     "compression": "none"
                 }
-            },
-            "file": {
-                "path":""
             },
             "frames": 10,
             "acquisition_id":"test_2",

--- a/data/test/integrationTest/config/mercury-fp.json
+++ b/data/test/integrationTest/config/mercury-fp.json
@@ -11,7 +11,7 @@
             "load": {
                 "index":"hdf",
                 "name":"FileWriterPlugin",
-                "library":"${ODIN_PREFIX}/lib/libHdf5Plugin.so"
+                "library":"${INSTALL_PREFIX}/lib/libHdf5Plugin.so"
             }
         }
     },
@@ -74,9 +74,6 @@
                     "chunks": [1, 80, 80],
                     "compression": "none"
                 }
-            },
-            "file": {
-                "path":""
             },
             "frames": 10,
             "acquisition_id":"test_1",

--- a/data/test/integrationTest/config/mercury.json
+++ b/data/test/integrationTest/config/mercury.json
@@ -2,25 +2,25 @@
     "Main": {
         "receiver": {
             "process": true,
-            "command": "${ODIN_PREFIX}\/bin\/frameReceiver",
+            "command": "${INSTALL_PREFIX}\/bin\/frameReceiver",
             "pos-args": "",
-            "sleep": 10
+            "sleep": 2
         },
         "processor": {
             "process": true,
-            "command": "${ODIN_PREFIX}\/bin\/frameProcessor",
+            "command": "${INSTALL_PREFIX}\/bin\/frameProcessor",
             "pos-args": "",
-            "sleep": 10
+            "sleep": 2
         },
         "simulator": {
             "process": false,
-            "command": "${ODIN_PREFIX}\/bin\/frameSimulator",
+            "command": "${INSTALL_PREFIX}\/bin\/frameSimulator",
             "pos-args": "Mercury",
             "sleep": 1
         },
         "test": {
             "process": false,
-            "command": "${ODIN_PREFIX}\/bin\/frameTests",
+            "command": "${INSTALL_PREFIX}\/bin\/frameTests --log_level=all -- ",
             "pos-args": "",
             "sleep": 1
         }
@@ -45,7 +45,6 @@
     },
     "test":
     {
-        "json": "${INSTALL_PREFIX}\/test_config\/test.json",
-        "log_level": "ALL"
+        "json": "${INSTALL_PREFIX}\/test_config\/test.json"
     }
 }


### PR DESCRIPTION
    Streamlines config json files to single INSTALL_PREFIX var (ODIN_PREFIX used in places)
    Prevents frameTests rejecting outdated log_level syntax.